### PR TITLE
[s3tokenizer] Support online extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,13 @@ class SpeechLLM(nn.Module):
     def __init__(self, ...):
         ...
         self.speech_tokenizer = s3tokenizer.load_model("speech_tokenizer_v1")
+        self.speech_tokenizer.freeze()
 
     def forward(self, speech: Tensor, speech_lens: Tensor, text_ids: Tensor, ...):
         ...
-        speech_codes = self.speech_tokenizer(speech, speech_lens)
+        speech_codes, speech_codes_lens = self.speech_tokenizer.quantize(speech, speech_lens)
+        speech_codes = speech_codes.clone()  # for backward compatbility
+        speech_codes_lens = speeech_codes_lens.clone()  # for backward compatbility
 ```
 
 </sub>
@@ -133,4 +136,4 @@ class SpeechLLM(nn.Module):
 
 - [x] Usage-1: Offline batch inference
 - [x] Usage-2: Distributed offline batch inference via command-line tools
-- [ ] Usage-3: Online speech code extraction
+- [x] Usage-3: Online speech code extraction

--- a/s3tokenizer/model.py
+++ b/s3tokenizer/model.py
@@ -302,3 +302,8 @@ class S3Tokenizer(nn.Module):
     def init_from_pt(self, ckpt_path: str):
         ckpt = torch.load(ckpt_path, map_location="cpu", mmap=True)
         self.load_state_dict(ckpt, strict=True)
+
+    def freeze(self):
+        for _, param in self.named_parameters():
+            param.requires_grad = False
+


### PR DESCRIPTION
```py
import torch
import s3tokenizer

from torch.nn.utils import clip_grad_norm_                                                                                                                                                                                                                  

class LM(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.tokenizer = s3tokenizer.load_model("speech_tokenizer_v1")
        self.tokenizer.freeze()
        self.emb = torch.nn.Embedding(4096, 64)
        self.proj = torch.nn.Linear(64, 256)

    def forward(self, speech, speech_len):
        code, code_len = self.tokenizer.quantize(speech, speech_len)
        code = code.clone()
        code_len = code_len.clone()
        code_emb = self.emb(code)
        return self.proj(code_emb)


model = LM()
optimizer = torch.optim.Adam(model.parameters())

for epoch in range(100):
    speech = torch.randn(5, 128, 35)  # (batch, nmels, time)
    speech_len = torch.tensor([35, 30, 10, 25, 31])
    loss = model(speech, speech_len).sum()
    loss.backward()
    grad_norm = clip_grad_norm_(model.parameters(), 5.0)
    if torch.isfinite(grad_norm):
        optimizer.step()
    optimizer.zero_grad()
    print(f"epoch {epoch}:\n\tmodel.proj.weight.mean(): {model.proj.weight.mean()}\n\tmodel.proj.weight[0, :3]: {model.proj.weight[0, :3].tolist()}")
    print(f"\n\tmodel.tokenizer.encoder.blocks[0].attn.query.weight.mean(): {model.tokenizer.encoder.blocks[0].attn.query.weight.mean()}\n\tmodel.tokenizer.encoder.blocks[0].attn.query.weight[0, :3]: {model.tokenizer.encoder.blocks[0].attn.query.weight[0, :3].tolist()}")
    print(f"\n\tmodel.tokenizer.encoder.blocks[5].attn.query.weight.mean(): {model.tokenizer.encoder.blocks[5].attn.query.weight.mean()}\n\tmodel.tokenizer.encoder.blocks[5].attn.query.weight[0, :3]: {model.tokenizer.encoder.blocks[5].attn.query.weight[0, :3].tolist()}")
    print(f"\n\tmodel.tokenizer.quantizer._codebook.embed.mean(): {model.tokenizer.quantizer._codebook.embed.mean()}\n\tmodel.tokenizer.quantizer._codebook.embed[0, :3]: {model.tokenizer.quantizer._codebook.embed[0, :3].tolist()}")
```


output:

```sh
...
epoch 54:
        model.proj.weight.mean(): 0.0038274824619293213
        model.proj.weight[0, :3]: [0.025155911222100258, -0.06667553633451462, -0.17137625813484192]
        model.tokenizer.encoder.blocks[0].attn.query.weight.mean(): -0.0002658642770256847
        model.tokenizer.encoder.blocks[0].attn.query.weight[0, :3]: [0.005808881483972073, -0.016306020319461823, 0.012763838283717632]                                                                                                                     
        model.tokenizer.encoder.blocks[5].attn.query.weight.mean(): 1.1887313121405896e-05
        model.tokenizer.encoder.blocks[5].attn.query.weight[0, :3]: [0.10840193927288055, -0.0034217487554997206, 0.0066123721189796925]                                                                                                                    
        model.tokenizer.quantizer._codebook.embed.mean(): -1.4890872989781201e-05
        model.tokenizer.quantizer._codebook.embed[0, :3]: [-8.804625394986942e-05, -0.0006335334037430584, -0.00022579828510060906]
epoch 55:
        model.proj.weight.mean(): 0.003920719958841801
        model.proj.weight[0, :3]: [0.02555905096232891, -0.06754206120967865, -0.1723678708076477]
        model.tokenizer.encoder.blocks[0].attn.query.weight.mean(): -0.0002658642770256847
        model.tokenizer.encoder.blocks[0].attn.query.weight[0, :3]: [0.005808881483972073, -0.016306020319461823, 0.012763838283717632]
        model.tokenizer.encoder.blocks[5].attn.query.weight.mean(): 1.1887313121405896e-05
        model.tokenizer.encoder.blocks[5].attn.query.weight[0, :3]: [0.10840193927288055, -0.0034217487554997206, 0.0066123721189796925]
        model.tokenizer.quantizer._codebook.embed.mean(): -1.4890872989781201e-05
        model.tokenizer.quantizer._codebook.embed[0, :3]: [-8.804625394986942e-05, -0.0006335334037430584, -0.00022579828510060906]
...
```