### PR TITLE
Return Integer Indices in FSQCodebook.encode

### DIFF
--- a/s3tokenizer/model_v2.py
+++ b/s3tokenizer/model_v2.py
@@ -106,7 +106,7 @@ class FSQCodebook(torch.nn.Module):
         powers = torch.pow(self.level,
                            torch.arange(2**self.level, device=x.device))
         mu = torch.sum(h * powers.unsqueeze(0), dim=-1)
-        ind = mu.reshape(x_shape[0], x_shape[1])
+        ind = mu.reshape(x_shape[0], x_shape[1]).int()
         return ind
 
     @torch.inference_mode()


### PR DESCRIPTION
Original output:
```
{"key": "6313_76958_000040_000000-0", "code": [1759.0, 4350.0, 2147.0, 2162.0, 4322.0, 4051.0, 5304.0, 4542.0, 2391.0, 1707.0, 5967.0, 6537.0, 1441.0, 110.0, 59.0, 2246.0, 2252.0, 4438.0, 5483.0, 4917.0, 4920.0, 2325.0, 1950.0, 4218.0, 1959.0, 3994.0, 2067.0, 2247.0, 3066.0, 5588.0, 3149.0, 3866.0, 3872.0, 1685.0, 1674.0, 3219.0, 641.0, 1349.0, 5693.0, 3422.0, 4299.0, 2160.0, 2420.0, 5065.0, 5073.0, 2526.0, 2031.0, 5835.0, 5832.0, 972.0]}
```

New output:
```
{"key": "6313_76958_000040_000000-0", "code": [1759, 4350, 2147, 2162, 4322, 4051, 5304, 4542, 2391, 1707, 5967, 6537, 1441, 110, 59, 2246, 2252, 4438, 5483, 4917, 4920, 2325, 1950, 4218, 1959, 3994, 2067, 2247, 3066, 5588, 3149, 3866, 3872, 1685, 1674, 3219, 641, 1349, 5693, 3422, 4299, 2160, 2420, 5065, 5073, 2526, 2031, 5835, 5832, 972]}
```

