### PR TITLE
fix miss rate in fp16 and bf16

### DIFF
--- a/s3tokenizer/model_v2.py
+++ b/s3tokenizer/model_v2.py
@@ -99,14 +99,14 @@ class FSQCodebook(torch.nn.Module):
         # pre-process
         x = self.preprocess(x)
         # quantize
-
-        h = self.project_down(x)
+        h = self.project_down(x).float()
         h = h.tanh()
         h = h * 0.9990000128746033
         h = h.round() + 1
         # h = ((self.level - 1) * h).round()  # range [-k, k]
-        powers = torch.pow(self.level,
-                           torch.arange(2**self.level, device=x.device))
+        powers = torch.pow(
+            self.level,
+            torch.arange(2**self.level, device=x.device, dtype=h.dtype))
         mu = torch.sum(h * powers.unsqueeze(0), dim=-1)
         ind = mu.reshape(x_shape[0], x_shape[1]).int()
         return ind


### PR DESCRIPTION
for bf16  on cuda 

<img width="660" alt="截屏2025-01-14 19 51 25" src="https://github.com/user-attachments/assets/ce38e161-d579-4b05-86c7-55ca1efe8095" />


for fp16 on cuda:
<img width="612" alt="截屏2025-01-14 19 52 19" src="https://github.com/user-attachments/assets/02d2b29c-28c3-4644-a9c6-7a4db345fd16" />
