### PR TITLE
missrate 0.2% -> 0.5%

### DIFF
--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -310,9 +310,8 @@ def test_torch_vs_onnx_short_audio(model_name, test_audio_suite):
 
     # For short audio, we expect reasonable match rate
     for r in results:
-        # NOTE(xcsong): 0.2% is a reasonable miss rate for long audio, since we drop the last overlap part.
         assert r[
-            'miss_rate'] < 0.2, f"Miss rate too high for {model_name}: {r['miss_rate']:.2f}%"
+            'miss_rate'] < 0.5, f"Miss rate too high for {model_name}: {r['miss_rate']:.2f}%"
 
     print(f"\n{model_name} Short Audio Summary:")
     print(f"  Successful tests: {len(successful_tests)}/{len(results)}")
@@ -365,9 +364,9 @@ def test_torch_vs_onnx_long_audio(model_name, test_audio_suite):
     print(f"  Successful ONNX tests: {len(successful_tests)}")
 
     for r in results:
-        # NOTE(xcsong): 0.2% is a reasonable miss rate for long audio, since we drop the last overlap part.
+        # NOTE(xcsong): 0.5% is a reasonable miss rate for long audio, since we drop the last overlap part.
         assert r[
-            'miss_rate'] < 0.2, f"Miss rate too high for {model_name}: {r['miss_rate']}%"
+            'miss_rate'] < 0.5, f"Miss rate too high for {model_name}: {r['miss_rate']}%"
 
     # The main requirement is that Torch always works
     print("  ✅ Torch processing works reliably for all long audio")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed the acceptable miss rate threshold in ONNX vs Torch tokenization comparison tests, allowing up to 0.5% miss rate for both short and long audio scenarios. Updated related comments to reflect the new threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->