### PR TITLE
feat: support speech_tokenizer_v3_25hz

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository undertakes a reverse engineering of the S3Tokenizer, offering:
 - [x] Model: [S3Tokenizer V1 50hz](https://modelscope.cn/models/iic/CosyVoice-300M)
 - [x] Model: [S3Tokenizer V1 25hz](https://modelscope.cn/models/iic/CosyVoice-300M-25Hz)
 - [x] Model: [S3Tokenizer V2 25hz](https://modelscope.cn/models/iic/CosyVoice2-0.5B)
+- [x] Model: [S3Tokenizer V3 25hz](https://modelscope.cn/models/FunAudioLLM/Fun-CosyVoice3-0.5B-2512)
 
 
 # Setup
@@ -34,7 +35,7 @@ pip install s3tokenizer
 ```py
 import s3tokenizer
 
-tokenizer = s3tokenizer.load_model("speech_tokenizer_v1").cuda()  # or "speech_tokenizer_v1_25hz speech_tokenizer_v2_25hz"
+tokenizer = s3tokenizer.load_model("speech_tokenizer_v1").cuda()  # or "speech_tokenizer_v1_25hz speech_tokenizer_v2_25hz speech_tokenizer_v3_25hz"
 
 mels = []
 wav_paths = ["s3tokenizer/assets/BAC009S0764W0121.wav", "s3tokenizer/assets/BAC009S0764W0122.wav"]
@@ -57,7 +58,7 @@ s3tokenizer --wav_scp xxx.scp \
             --device "cpu" \
             --output_dir "./" \
             --batch_size 32 \
-            --model "speech_tokenizer_v1"  # or "speech_tokenizer_v1_25hz speech_tokenizer_v2_25hz"
+            --model "speech_tokenizer_v1"  # or "speech_tokenizer_v1_25hz speech_tokenizer_v2_25hz speech_tokenizer_v3_25hz"
 ```
 
 
@@ -75,7 +76,7 @@ torchrun --nproc_per_node=8 --nnodes=1 \
                 --device "cuda" \
                 --output_dir "./" \
                 --batch_size 32 \
-                --model "speech_tokenizer_v1"  # or "speech_tokenizer_v1_25hz speech_tokenizer_v2_25hz"
+                --model "speech_tokenizer_v1"  # or "speech_tokenizer_v1_25hz speech_tokenizer_v2_25hz speech_tokenizer_v3_25hz"
 ```
 
 

--- a/s3tokenizer/__init__.py
+++ b/s3tokenizer/__init__.py
@@ -25,14 +25,16 @@ from typing import List, Union
 from tqdm import tqdm
 
 from s3tokenizer.model_v2 import S3TokenizerV2
+from s3tokenizer.model_v3 import S3TokenizerV3
 
 from .model import S3Tokenizer
 from .utils import (load_audio, log_mel_spectrogram, make_non_pad_mask,
-                    mask_to_bias, onnx2torch, padding, merge_tokenized_segments)
+                    mask_to_bias, merge_tokenized_segments, onnx2torch,
+                    onnx2torch_v3, padding)
 
 __all__ = [
     'load_audio', 'log_mel_spectrogram', 'make_non_pad_mask', 'mask_to_bias',
-    'onnx2torch', 'padding', 'merge_tokenized_segments'
+    'onnx2torch', 'onnx2torch_v3', 'padding', 'merge_tokenized_segments'
 ]
 _MODELS = {
     "speech_tokenizer_v1":
@@ -44,6 +46,9 @@ _MODELS = {
     "speech_tokenizer_v2_25hz":
     "https://www.modelscope.cn/models/iic/CosyVoice2-0.5B/"
     "resolve/master/speech_tokenizer_v2.onnx",
+    "speech_tokenizer_v3_25hz":
+    "https://www.modelscope.cn/models/FunAudioLLM/Fun-CosyVoice3-0.5B-2512/"
+    "resolve/master/speech_tokenizer_v3.onnx",
 }
 
 _SHA256S = {
@@ -53,6 +58,8 @@ _SHA256S = {
     "56285ddd4a83e883ee0cb9f8d69c1089b53a94b1f78ff7e4a0224a27eb4cb486",
     "speech_tokenizer_v2_25hz":
     "d43342aa12163a80bf07bffb94c9de2e120a8df2f9917cd2f642e7f4219c6f71",
+    "speech_tokenizer_v3_25hz":
+    "23236a74175dbdda47afc66dbadd5bcb41303c467a57c261cb8539ad9db9208d",
 }
 
 
@@ -144,7 +151,9 @@ def load_model(
     else:
         raise RuntimeError(
             f"Model {name} not found; available models = {available_models()}")
-    if 'v2' in name:
+    if 'v3' in name:
+        model = S3TokenizerV3(name)
+    elif 'v2' in name:
         model = S3TokenizerV2(name)
     else:
         model = S3Tokenizer(name)

--- a/s3tokenizer/model.py
+++ b/s3tokenizer/model.py
@@ -43,7 +43,13 @@ class ModelConfig:
 class LayerNorm(nn.LayerNorm):
 
     def forward(self, x: Tensor) -> Tensor:
-        return super().forward(x.float()).type(x.dtype)
+        return F.layer_norm(
+            x.float(),
+            self.normalized_shape,
+            self.weight.float() if self.weight is not None else None,
+            self.bias.float() if self.bias is not None else None,
+            self.eps,
+        ).type(x.dtype)
 
 
 class Linear(nn.Linear):

--- a/s3tokenizer/model_v2.py
+++ b/s3tokenizer/model_v2.py
@@ -173,6 +173,7 @@ class FSMNMultiHeadAttention(MultiHeadAttention):
             (self.left_padding, self.right_padding), 0.0)
 
         self.use_sdpa = use_sdpa
+        self.key = Linear(n_state, n_state, bias=False)
 
     def forward_fsmn(self,
                      inputs: torch.Tensor,
@@ -264,7 +265,7 @@ class ResidualAttentionBlock(torch.nn.Module):
                                            n_head,
                                            kernel_size,
                                            use_sdpa=use_sdpa)
-        self.attn_ln = LayerNorm(n_state, eps=1e-6)
+        self.attn_ln = LayerNorm(n_state, eps=1e-5)
 
         n_mlp = n_state * 4
 

--- a/s3tokenizer/model_v2.py
+++ b/s3tokenizer/model_v2.py
@@ -55,8 +55,8 @@ def apply_rotary_emb(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     real = torch.view_as_real(freqs_cis)
     cos, sin = real[:, :, 0], real[:, :, 1]
-    cos = cos.unsqueeze(0).unsqueeze(2)
-    sin = sin.unsqueeze(0).unsqueeze(2)
+    cos = cos.unsqueeze(0).unsqueeze(2).to(xq.dtype)
+    sin = sin.unsqueeze(0).unsqueeze(2).to(xq.dtype)
 
     D = xq.shape[-1]
     half_l, half_r = xq[:, :, :, :D // 2], xq[:, :, :, D // 2:]

--- a/s3tokenizer/model_v3.py
+++ b/s3tokenizer/model_v3.py
@@ -137,14 +137,6 @@ class AudioEncoderV3(torch.nn.Module):
         mask_pad = mask.transpose(1, 2)
         mask = mask_to_bias(mask, x.dtype)
 
-        tmp = torch.view_as_real(freqs_cis)
-        cos, sin = tmp[:, :, 0], tmp[:, :, 1]
-
-        cos = torch.cat((cos, cos), dim=-1)
-        sin = torch.cat((sin, sin), dim=-1)
-        cos = cos.unsqueeze(0).unsqueeze(2)
-        sin = sin.unsqueeze(0).unsqueeze(2)
-
         for block in self.blocks:
             x = block(x, mask.unsqueeze(1), mask_pad, freqs_cis[:x.size(1)])
 
@@ -196,7 +188,8 @@ class S3TokenizerV3(torch.nn.Module):
     @torch.inference_mode()
     def _quantize_mixed_batch(
             self, mel: torch.Tensor, mel_len: torch.Tensor,
-            long_audio_mask: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+            long_audio_mask: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
 
         batch_size = mel.size(0)
         sample_rate = 16000

--- a/s3tokenizer/model_v3.py
+++ b/s3tokenizer/model_v3.py
@@ -64,12 +64,12 @@ class ResidualAttentionBlockV3(torch.nn.Module):
                                          n_head,
                                          kernel_size,
                                          use_sdpa=use_sdpa)
-        self.attn_ln = LayerNorm(n_state, eps=1e-6)
+        self.attn_ln = LayerNorm(n_state, eps=1e-5)
         n_mlp = n_state * 4
         # Set bias=True for MLP Linear layers
         self.mlp = torch.nn.Sequential(Linear(n_state, n_mlp), torch.nn.GELU(),
                                        Linear(n_mlp, n_state))
-        self.mlp_ln = LayerNorm(n_state, eps=1e-6)
+        self.mlp_ln = LayerNorm(n_state, eps=1e-5)
 
     def forward(self,
                 x: torch.Tensor,

--- a/s3tokenizer/model_v3.py
+++ b/s3tokenizer/model_v3.py
@@ -45,9 +45,9 @@ class MultiHeadAttentionV3(FSMNMultiHeadAttention):
                  kernel_size: int = 31,
                  use_sdpa: bool = False):
         super().__init__(n_state, n_head, kernel_size, use_sdpa)
-        # Override linears to be bias=True (default)
+        # Override linears: query/value/out use bias=True, key uses bias=False
         self.query = Linear(n_state, n_state)
-        self.key = Linear(n_state, n_state)
+        self.key = Linear(n_state, n_state, bias=False)
         self.value = Linear(n_state, n_state)
         self.out = Linear(n_state, n_state)
 

--- a/s3tokenizer/model_v3.py
+++ b/s3tokenizer/model_v3.py
@@ -1,0 +1,346 @@
+# Copyright (c)  (Mddct: Dinghao Zhou)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+
+from s3tokenizer.model import Conv1d, LayerNorm, Linear
+# Re-use V2 components where possible, but we might need specific V3 tweaks
+from s3tokenizer.model_v2 import (FSMNMultiHeadAttention,
+                                  FSQVectorQuantization, precompute_freqs_cis)
+from s3tokenizer.utils import (make_non_pad_mask, mask_to_bias,
+                               merge_tokenized_segments, onnx2torch_v3)
+
+
+@dataclass
+class ModelConfigV3:
+    n_mels: int = 128
+    n_audio_ctx: int = 1500
+    n_audio_state: int = 1280
+    n_audio_head: int = 20
+    n_audio_layer: int = 12  # V3 has 12 layers
+    n_codebook_size: int = 3**8
+
+    use_sdpa: bool = False
+
+
+class MultiHeadAttentionV3(FSMNMultiHeadAttention):
+
+    def __init__(self,
+                 n_state: int,
+                 n_head: int,
+                 kernel_size: int = 31,
+                 use_sdpa: bool = False):
+        super().__init__(n_state, n_head, kernel_size, use_sdpa)
+        # Override linears to be bias=True (default)
+        self.query = Linear(n_state, n_state)
+        self.key = Linear(n_state, n_state)
+        self.value = Linear(n_state, n_state)
+        self.out = Linear(n_state, n_state)
+
+
+class ResidualAttentionBlockV3(torch.nn.Module):
+
+    def __init__(self,
+                 n_state: int,
+                 n_head: int,
+                 kernel_size: int = 31,
+                 use_sdpa: bool = False):
+        super().__init__()
+        self.attn = MultiHeadAttentionV3(n_state,
+                                         n_head,
+                                         kernel_size,
+                                         use_sdpa=use_sdpa)
+        self.attn_ln = LayerNorm(n_state, eps=1e-6)
+        n_mlp = n_state * 4
+        # Set bias=True for MLP Linear layers
+        self.mlp = torch.nn.Sequential(Linear(n_state, n_mlp), torch.nn.GELU(),
+                                       Linear(n_mlp, n_state))
+        self.mlp_ln = LayerNorm(n_state, eps=1e-6)
+
+    def forward(self,
+                x: torch.Tensor,
+                mask: Optional[torch.Tensor] = None,
+                mask_pad: Optional[torch.Tensor] = None,
+                freqs_cis: Optional[torch.Tensor] = None):
+        x = x + self.attn(
+            self.attn_ln(x), mask=mask, mask_pad=mask_pad,
+            freqs_cis=freqs_cis)[0]
+        x = x + self.mlp(self.mlp_ln(x))
+        return x
+
+
+class AudioEncoderV3(torch.nn.Module):
+
+    def __init__(
+        self,
+        n_mels: int,
+        n_state: int,
+        n_head: int,
+        n_layer: int,
+        stride: int,
+        use_sdpa: bool,
+    ):
+        super().__init__()
+        self.stride = stride
+
+        self.conv1 = Conv1d(n_mels,
+                            n_state,
+                            kernel_size=3,
+                            stride=stride,
+                            padding=1)
+        self.conv2 = Conv1d(n_state,
+                            n_state,
+                            kernel_size=3,
+                            stride=2,
+                            padding=1)
+        self.freqs_cis = precompute_freqs_cis(64, 1024 * 2)
+        # V3 uses the same ResidualAttentionBlock structure but more layers
+        self.blocks = torch.nn.ModuleList([
+            ResidualAttentionBlockV3(n_state, n_head, use_sdpa=use_sdpa)
+            for _ in range(n_layer)
+        ])
+
+    def forward(self, x: torch.Tensor,
+                x_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        x : torch.Tensor, shape = (batch_size, n_mels, T)
+            the mel spectrogram of the audio
+        x_len: torch.Tensor, shape = (batch_size,)
+            length of each audio in x
+        """
+        T = x.shape[-1]
+        mask = make_non_pad_mask(x_len, T).unsqueeze(1)
+        x = torch.nn.functional.gelu(self.conv1(x * mask))
+        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+        x_slen = (T + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+        mask = make_non_pad_mask(x_len, x_slen).unsqueeze(1)
+        x = torch.nn.functional.gelu(self.conv2(x * mask))
+        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // 2 + 1
+        x_slen = (x_slen + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+        mask = make_non_pad_mask(x_len, x_slen).unsqueeze(1)
+        x = x.permute(0, 2, 1)  # (B, T // 2, n_state)
+        freqs_cis = self.freqs_cis.to(x.device)
+        mask_pad = mask.transpose(1, 2)
+        mask = mask_to_bias(mask, x.dtype)
+
+        tmp = torch.view_as_real(freqs_cis)
+        cos, sin = tmp[:, :, 0], tmp[:, :, 1]
+
+        cos = torch.cat((cos, cos), dim=-1)
+        sin = torch.cat((sin, sin), dim=-1)
+        cos = cos.unsqueeze(0).unsqueeze(2)
+        sin = sin.unsqueeze(0).unsqueeze(2)
+
+        for block in self.blocks:
+            x = block(x, mask.unsqueeze(1), mask_pad, freqs_cis[:x.size(1)])
+
+        return x, x_len
+
+
+class S3TokenizerV3(torch.nn.Module):
+    """S3 tokenizer v3 implementation (inference-only).
+    Args:
+        config (ModelConfigV3): Config
+    """
+
+    def __init__(self, name: str, config: ModelConfigV3 = ModelConfigV3()):
+        super().__init__()
+        self.name = name
+        self.config = config
+        self.encoder = AudioEncoderV3(
+            self.config.n_mels,
+            self.config.n_audio_state,
+            self.config.n_audio_head,
+            self.config.n_audio_layer,
+            2,
+            self.config.use_sdpa,
+        )
+        self.quantizer = FSQVectorQuantization(
+            self.config.n_audio_state,
+            self.config.n_codebook_size,
+        )
+
+    def forward(self, mel: torch.Tensor,
+                mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.quantize(mel, mel_len)
+
+    @torch.inference_mode()
+    def quantize(self, mel: torch.Tensor,
+                 mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Re-use logic from V2 (copy-paste or inheritance? Inheritance is trickier with imports)
+        # Using exact same logic as V2 for now
+        max_frames = 3000
+        long_audio_mask = mel_len > max_frames
+
+        if long_audio_mask.any():
+            return self._quantize_mixed_batch(mel, mel_len, long_audio_mask,
+                                              max_frames)
+        else:
+            hidden, code_len = self.encoder(mel, mel_len)
+            code = self.quantizer.encode(hidden)
+            return code, code_len
+
+    @torch.inference_mode()
+    def _quantize_mixed_batch(
+            self, mel: torch.Tensor, mel_len: torch.Tensor,
+            long_audio_mask: torch.Tensor,
+            max_frames: int) -> Tuple[torch.Tensor, torch.Tensor]:
+
+        # Copy-paste from V2 because it relies on self.encoder which is V3 here
+        batch_size = mel.size(0)
+        sample_rate = 16000
+        hop_length = 160
+        window_size = 30
+        overlap = 4
+
+        frames_per_window = window_size * sample_rate // hop_length
+        frames_per_overlap = overlap * sample_rate // hop_length
+        frames_per_stride = frames_per_window - frames_per_overlap
+
+        all_segments = []
+        all_segments_len = []
+        segment_info = []
+
+        for batch_idx in range(batch_size):
+            audio_mel = mel[batch_idx]
+            audio_mel_len = mel_len[batch_idx]
+            is_long_audio = long_audio_mask[batch_idx].item()
+
+            if not is_long_audio:
+                segment = audio_mel[:, :audio_mel_len]
+                seg_len = audio_mel_len.item()
+                if seg_len < frames_per_window:
+                    pad_size = frames_per_window - seg_len
+                    segment = torch.nn.functional.pad(segment, (0, pad_size))
+                all_segments.append(segment)
+                all_segments_len.append(
+                    torch.tensor(seg_len, device=mel.device))
+                segment_info.append({
+                    'batch_idx': batch_idx,
+                    'is_long_audio': False,
+                    'segment_idx': 0,
+                    'total_segments': 1
+                })
+            else:
+                start = 0
+                segment_idx = 0
+                while start < audio_mel_len:
+                    end = min(start + frames_per_window, audio_mel_len)
+                    segment = audio_mel[:, start:end]
+                    seg_len = segment.size(1)
+                    if seg_len < frames_per_window:
+                        pad_size = frames_per_window - seg_len
+                        segment = torch.nn.functional.pad(
+                            segment, (0, pad_size))
+                    all_segments.append(segment)
+                    all_segments_len.append(
+                        torch.tensor(seg_len, device=mel.device))
+                    segment_info.append({
+                        'batch_idx': batch_idx,
+                        'is_long_audio': True,
+                        'segment_idx': segment_idx,
+                        'total_segments': None
+                    })
+                    segment_idx += 1
+                    start += frames_per_stride
+                total_segments = segment_idx
+                for info in segment_info:
+                    if info['batch_idx'] == batch_idx and info['is_long_audio']:
+                        info['total_segments'] = total_segments
+
+        if not all_segments:
+            return torch.zeros(batch_size,
+                               0,
+                               dtype=torch.long,
+                               device=mel.device), torch.zeros(
+                                   batch_size,
+                                   dtype=torch.long,
+                                   device=mel.device)
+
+        unified_batch_mel = torch.stack(all_segments)
+        unified_batch_lens = torch.stack(all_segments_len)
+
+        hidden, code_len = self.encoder(unified_batch_mel, unified_batch_lens)
+        codes = self.quantizer.encode(hidden)
+
+        results = {}
+
+        for seg_idx, info in enumerate(segment_info):
+            batch_idx = info['batch_idx']
+            is_long_audio = info['is_long_audio']
+
+            segment_code = codes[
+                seg_idx, :code_len[seg_idx].item()].cpu().numpy().tolist()
+
+            if not is_long_audio:
+                code_tensor = torch.tensor(segment_code,
+                                           dtype=torch.long,
+                                           device=mel.device)
+                results[batch_idx] = (code_tensor, len(segment_code))
+            else:
+                if batch_idx not in results:
+                    results[batch_idx] = []
+                results[batch_idx].append(segment_code)
+
+        for batch_idx in range(batch_size):
+            if long_audio_mask[batch_idx].item():
+                audio_codes = results[batch_idx]
+                token_rate = 25
+                merged_codes = merge_tokenized_segments(audio_codes,
+                                                        overlap=overlap,
+                                                        token_rate=token_rate)
+                merged_codes_tensor = torch.tensor(merged_codes,
+                                                   dtype=torch.long,
+                                                   device=mel.device)
+                results[batch_idx] = (merged_codes_tensor, len(merged_codes))
+
+        max_code_len = max(code_info[1] for code_info in results.values())
+        output_codes = torch.zeros(batch_size,
+                                   max_code_len,
+                                   dtype=torch.long,
+                                   device=mel.device)
+        output_codes_len = torch.zeros(batch_size,
+                                       dtype=torch.long,
+                                       device=mel.device)
+
+        for batch_idx, (code_tensor, code_len) in results.items():
+            output_codes[batch_idx, :code_len] = code_tensor
+            output_codes_len[batch_idx] = code_len
+
+        return output_codes, output_codes_len
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def init_from_onnx(self, onnx_path: str):
+        ckpt = onnx2torch_v3(onnx_path, None,
+                             False)  # Set verbose back to False
+        self.load_state_dict(ckpt, strict=False)
+
+    def init_from_pt(self, ckpt_path: str):
+        ckpt = torch.load(ckpt_path, map_location="cpu", mmap=True)
+        self.load_state_dict(ckpt, strict=True)
+
+    def load_state_dict(self, state_dict, strict=True):
+        # Allow loading state dict with missing keys (like LN bias) if strictly necessary
+        # But for now we try to stick to standard behavior
+        return super().load_state_dict(state_dict, strict=strict)
+
+    def freeze(self):
+        for _, param in self.named_parameters():
+            param.requires_grad = False

--- a/s3tokenizer/model_v3.py
+++ b/s3tokenizer/model_v3.py
@@ -187,8 +187,7 @@ class S3TokenizerV3(torch.nn.Module):
         long_audio_mask = mel_len > max_frames
 
         if long_audio_mask.any():
-            return self._quantize_mixed_batch(mel, mel_len, long_audio_mask,
-                                              max_frames)
+            return self._quantize_mixed_batch(mel, mel_len, long_audio_mask)
         else:
             hidden, code_len = self.encoder(mel, mel_len)
             code = self.quantizer.encode(hidden)
@@ -197,10 +196,8 @@ class S3TokenizerV3(torch.nn.Module):
     @torch.inference_mode()
     def _quantize_mixed_batch(
             self, mel: torch.Tensor, mel_len: torch.Tensor,
-            long_audio_mask: torch.Tensor,
-            max_frames: int) -> Tuple[torch.Tensor, torch.Tensor]:
+            long_audio_mask: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
 
-        # Copy-paste from V2 because it relies on self.encoder which is V3 here
         batch_size = mel.size(0)
         sample_rate = 16000
         hop_length = 160

--- a/s3tokenizer/model_v3.py
+++ b/s3tokenizer/model_v3.py
@@ -130,7 +130,7 @@ class AudioEncoderV3(torch.nn.Module):
         mask = make_non_pad_mask(x_len, x_slen).unsqueeze(1)
         x = torch.nn.functional.gelu(self.conv2(x * mask))
         x_len = (x_len + 2 - 1 * (3 - 1) - 1) // 2 + 1
-        x_slen = (x_slen + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+        x_slen = (x_slen + 2 - 1 * (3 - 1) - 1) // 2 + 1
         mask = make_non_pad_mask(x_len, x_slen).unsqueeze(1)
         x = x.permute(0, 2, 1)  # (B, T // 2, n_state)
         freqs_cis = self.freqs_cis.to(x.device)

--- a/test/test_batch_efficiency.py
+++ b/test/test_batch_efficiency.py
@@ -5,9 +5,10 @@ Test the efficiency improvement of new batch processing functionality for mixed 
 """
 
 import time
-import torch
+
 import pytest
 import s3tokenizer
+import torch
 
 
 def create_test_audio(duration_seconds=20, sample_rate=16000):
@@ -49,7 +50,7 @@ def long_audios():
 
 @pytest.mark.parametrize("model_name", [
     "speech_tokenizer_v1_25hz", "speech_tokenizer_v1",
-    "speech_tokenizer_v2_25hz"
+    "speech_tokenizer_v2_25hz", "speech_tokenizer_v3_25hz"
 ])
 def test_batch_efficiency(test_audios, model_name):
     """Test batch processing efficiency for different models"""
@@ -164,7 +165,7 @@ def test_batch_efficiency(test_audios, model_name):
 
 @pytest.mark.parametrize("model_name", [
     "speech_tokenizer_v1_25hz", "speech_tokenizer_v1",
-    "speech_tokenizer_v2_25hz"
+    "speech_tokenizer_v2_25hz", "speech_tokenizer_v3_25hz"
 ])
 def test_pure_long_audio_batch(long_audios, model_name):
     """Test pure long audio batch processing for different models"""
@@ -214,7 +215,7 @@ def test_pure_long_audio_batch(long_audios, model_name):
 
 @pytest.mark.parametrize("model_name", [
     "speech_tokenizer_v1_25hz", "speech_tokenizer_v1",
-    "speech_tokenizer_v2_25hz"
+    "speech_tokenizer_v2_25hz", "speech_tokenizer_v3_25hz"
 ])
 def test_model_loading(model_name):
     """Test that all models can be loaded successfully"""
@@ -230,7 +231,7 @@ def test_model_loading(model_name):
 
 @pytest.mark.parametrize("model_name", [
     "speech_tokenizer_v1_25hz", "speech_tokenizer_v1",
-    "speech_tokenizer_v2_25hz"
+    "speech_tokenizer_v2_25hz", "speech_tokenizer_v3_25hz"
 ])
 def test_single_audio_processing(model_name):
     """Test single audio processing for different models"""

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -4,7 +4,7 @@
 
 import os
 import time
-from typing import Dict, Any
+from typing import Any, Dict
 
 import numpy as np
 import onnxruntime
@@ -271,7 +271,7 @@ def compare_torch_vs_onnx_single(model_name: str, audio: torch.Tensor,
 
 @pytest.mark.parametrize("model_name", [
     "speech_tokenizer_v1", "speech_tokenizer_v1_25hz",
-    "speech_tokenizer_v2_25hz"
+    "speech_tokenizer_v2_25hz", "speech_tokenizer_v3_25hz"
 ])
 def test_torch_vs_onnx_short_audio(model_name, test_audio_suite):
     """Test torch vs onnx for short audio (<=30s)"""
@@ -310,8 +310,9 @@ def test_torch_vs_onnx_short_audio(model_name, test_audio_suite):
 
     # For short audio, we expect reasonable match rate
     for r in results:
+        threshold = 2.0 if "v3" in model_name else 0.5
         assert r[
-            'miss_rate'] < 0.5, f"Miss rate too high for {model_name}: {r['miss_rate']:.2f}%"
+            'miss_rate'] < threshold, f"Miss rate too high for {model_name}: {r['miss_rate']:.2f}%"
 
     print(f"\n{model_name} Short Audio Summary:")
     print(f"  Successful tests: {len(successful_tests)}/{len(results)}")
@@ -319,7 +320,7 @@ def test_torch_vs_onnx_short_audio(model_name, test_audio_suite):
 
 @pytest.mark.parametrize("model_name", [
     "speech_tokenizer_v1", "speech_tokenizer_v1_25hz",
-    "speech_tokenizer_v2_25hz"
+    "speech_tokenizer_v2_25hz", "speech_tokenizer_v3_25hz"
 ])
 def test_torch_vs_onnx_long_audio(model_name, test_audio_suite):
     """Test torch vs onnx for long audio (>30s) with ONNX sliding window implementation"""
@@ -365,8 +366,9 @@ def test_torch_vs_onnx_long_audio(model_name, test_audio_suite):
 
     for r in results:
         # NOTE(xcsong): 0.5% is a reasonable miss rate for long audio, since we drop the last overlap part.
+        threshold = 2.0 if "v3" in model_name else 0.5
         assert r[
-            'miss_rate'] < 0.5, f"Miss rate too high for {model_name}: {r['miss_rate']}%"
+            'miss_rate'] < threshold, f"Miss rate too high for {model_name}: {r['miss_rate']}%"
 
     # The main requirement is that Torch always works
     print("  ✅ Torch processing works reliably for all long audio")

--- a/test/test_onnx.py
+++ b/test/test_onnx.py
@@ -310,9 +310,8 @@ def test_torch_vs_onnx_short_audio(model_name, test_audio_suite):
 
     # For short audio, we expect reasonable match rate
     for r in results:
-        threshold = 2.0 if "v3" in model_name else 0.5
         assert r[
-            'miss_rate'] < threshold, f"Miss rate too high for {model_name}: {r['miss_rate']:.2f}%"
+            'miss_rate'] < 0.5, f"Miss rate too high for {model_name}: {r['miss_rate']:.2f}%"
 
     print(f"\n{model_name} Short Audio Summary:")
     print(f"  Successful tests: {len(successful_tests)}/{len(results)}")
@@ -366,9 +365,8 @@ def test_torch_vs_onnx_long_audio(model_name, test_audio_suite):
 
     for r in results:
         # NOTE(xcsong): 0.5% is a reasonable miss rate for long audio, since we drop the last overlap part.
-        threshold = 2.0 if "v3" in model_name else 0.5
         assert r[
-            'miss_rate'] < threshold, f"Miss rate too high for {model_name}: {r['miss_rate']}%"
+            'miss_rate'] < 0.5, f"Miss rate too high for {model_name}: {r['miss_rate']}%"
 
     # The main requirement is that Torch always works
     print("  ✅ Torch processing works reliably for all long audio")


### PR DESCRIPTION
- Added S3TokenizerV3, AudioEncoderV3, MultiHeadAttentionV3, ResidualAttentionBlockV3 in model_v3.py
- Implemented onnx2torch_v3 with bias detection for correct V3 conversion
- Updated LayerNorm to handle bfloat16 mixed precision on CPU
- Fixed apply_rotary_emb to avoid upcasting bfloat16
- Updated test_onnx.py to include v3 model tests with appropriate thresholds
- Updated README with V3 support info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for S3Tokenizer V3 (25 Hz): new V3 tokenizer pipeline, long-audio mixed-batch handling, and a V3 ONNX→PyTorch conversion utility.

* **Bug Fixes**
  * Improved numeric robustness in rotary embeddings and layer normalization for more stable behavior.

* **Documentation**
  * README and usage examples updated to list the new model variant.

* **Tests**
  * Test suite updated to include the V3 model variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->