### PR TITLE
Fix FSQ GPU code packing precision bug

### DIFF
--- a/s3tokenizer/model_v2.py
+++ b/s3tokenizer/model_v2.py
@@ -102,13 +102,17 @@ class FSQCodebook(torch.nn.Module):
         h = self.project_down(x).float()
         h = h.tanh()
         h = h * 0.9990000128746033
-        h = h.round() + 1
-        # h = ((self.level - 1) * h).round()  # range [-k, k]
-        powers = torch.pow(
-            self.level,
-            torch.arange(2**self.level, device=x.device, dtype=h.dtype))
+        h = (h.round() + 1).to(torch.int64)
+        # Use integer arithmetic for code packing. Floating-point pow() on some
+        # CUDA stacks produces values like 242.99998 for 3**5, and the final
+        # int() cast truncates the packed token id by 1.
+        powers = torch.tensor(
+            [self.level**i for i in range(2**self.level)],
+            device=x.device,
+            dtype=torch.int64,
+        )
         mu = torch.sum(h * powers.unsqueeze(0), dim=-1)
-        ind = mu.reshape(x_shape[0], x_shape[1]).int()
+        ind = mu.reshape(x_shape[0], x_shape[1]).to(torch.int32)
         return ind
 
     @torch.inference_mode()

--- a/test/test_fsq_codebook.py
+++ b/test/test_fsq_codebook.py
@@ -1,0 +1,46 @@
+import torch
+from torch import nn
+
+from s3tokenizer.model_v2 import FSQCodebook
+
+
+class FakeProjectDown(nn.Module):
+
+    def __init__(self, output: torch.Tensor):
+        super().__init__()
+        self.register_buffer("output", output)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch, steps = x.shape[:2]
+        assert self.output.shape[:2] == (batch, steps)
+        return self.output.to(x.device)
+
+
+def test_fsq_code_packing_returns_exact_token_ids():
+    codebook = FSQCodebook(dim=8, level=3)
+    digits = torch.tensor(
+        [[[2, 0, 0, 0, 0, 2, 0, 0], [1, 0, 0, 0, 0, 2, 0, 0]]],
+        dtype=torch.int64,
+    )
+    pre_tanh = torch.where(
+        digits == 2,
+        torch.full_like(digits, 20),
+        torch.where(digits == 1, torch.zeros_like(digits), torch.full_like(digits, -20)),
+    ).to(torch.float32)
+    codebook.project_down = FakeProjectDown(pre_tanh)
+
+    dummy_hidden = torch.zeros(1, 2, 8)
+    packed = codebook.encode(dummy_hidden)
+
+    assert torch.equal(packed, torch.tensor([[488, 487]], dtype=torch.int32))
+
+
+def test_cuda_float_pow_can_be_non_integer():
+    if not torch.cuda.is_available():
+        return
+
+    powers = torch.pow(3, torch.arange(8, device="cuda", dtype=torch.float32)).cpu()
+
+    # On some CUDA stacks, 3**5 becomes 242.99998 instead of 243.0.
+    # This test documents the motivation for avoiding float pow in code packing.
+    assert powers[5].item() <= 243.0


### PR DESCRIPTION
  ## Summary
 Fixes xingchensong/S3Tokenizer#49
 Fix a CUDA-specific precision issue in `FSQCodebook.encode()`.

  On some CUDA stacks, floating-point `torch.pow(3, x)` does not always return
  exact integers. For example, `3**5` can become `242.99998`, and the subsequent
  `.int()` cast truncates the packed token id by 1.

  This caused systematic token mismatches such as:
  - 243 -> 242
  - 488 -> 487
  - 245 -> 244

  ## Root Cause

  `FSQCodebook.encode()` used floating-point arithmetic for code packing:
  - float `torch.pow(...)`
  - float accumulation
  - final `.int()` truncation

  On affected GPUs this produced incorrect packed token ids.

  ## Fix

  - convert rounded FSQ digits to `int64`
  - build integer powers of `self.level`
  - perform packing in integer space
  - return `int32`

  ## Validation

  - reproduced CUDA `torch.pow(3, x)` precision issue locally
  - added regression test for exact FSQ code packing
  - verified the environment2 GPU mismatch count dropped from 19 to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical precision in quantization code packing through optimized integer-based computation for more accurate and consistent token ID generation.

* **Tests**
  * Added comprehensive unit tests to validate quantization accuracy and verify numerical stability across hardware platforms, including CUDA compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->