### PR TITLE
Fix long-audio token clock truncation

### DIFF
--- a/s3tokenizer/chunking.py
+++ b/s3tokenizer/chunking.py
@@ -1,0 +1,25 @@
+"""Pure frame-window helpers used by long-audio tokenization."""
+
+from __future__ import annotations
+
+
+def long_audio_frame_ranges(
+    total_frames: int,
+    *,
+    window_frames: int,
+    stride_frames: int,
+) -> list[tuple[int, int]]:
+    """Cover an utterance without emitting a redundant terminal window."""
+    if total_frames < 0 or window_frames <= 0 or stride_frames <= 0:
+        raise ValueError("frame counts must be nonnegative and window/stride positive")
+    if stride_frames > window_frames:
+        raise ValueError("stride cannot exceed the window")
+    ranges: list[tuple[int, int]] = []
+    start = 0
+    while start < total_frames:
+        end = min(start + window_frames, total_frames)
+        ranges.append((start, end))
+        if end >= total_frames:
+            break
+        start += stride_frames
+    return ranges

--- a/s3tokenizer/model_v2.py
+++ b/s3tokenizer/model_v2.py
@@ -18,6 +18,7 @@ from typing import Optional, Tuple
 import torch
 from einops import rearrange
 
+from s3tokenizer.chunking import long_audio_frame_ranges
 from s3tokenizer.model import Conv1d, LayerNorm, Linear, MultiHeadAttention
 from s3tokenizer.utils import make_non_pad_mask, mask_to_bias, onnx2torch, merge_tokenized_segments
 
@@ -481,10 +482,11 @@ class S3TokenizerV2(torch.nn.Module):
                 })
             else:
                 # Long audio: split into multiple segments
-                start = 0
                 segment_idx = 0
-                while start < audio_mel_len:
-                    end = min(start + frames_per_window, audio_mel_len)
+                for start, end in long_audio_frame_ranges(
+                        int(audio_mel_len.item()),
+                        window_frames=frames_per_window,
+                        stride_frames=frames_per_stride):
                     segment = audio_mel[:, start:end]
 
                     seg_len = segment.size(1)
@@ -505,7 +507,6 @@ class S3TokenizerV2(torch.nn.Module):
                     })
 
                     segment_idx += 1
-                    start += frames_per_stride
 
                 # Update total_segments info
                 total_segments = segment_idx

--- a/test/test_long_audio_clock.py
+++ b/test/test_long_audio_clock.py
@@ -1,0 +1,56 @@
+import importlib.util
+import math
+from pathlib import Path
+
+import pytest
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "s3tokenizer/chunking.py"
+SPEC = importlib.util.spec_from_file_location("s3tokenizer_chunking_test", SOURCE)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+long_audio_frame_ranges = MODULE.long_audio_frame_ranges
+
+
+def test_does_not_emit_redundant_sub_overlap_tail():
+    total_frames = 5201
+    ranges = long_audio_frame_ranges(
+        total_frames, window_frames=3000, stride_frames=2600
+    )
+    assert ranges == [(0, 3000), (2600, 5201)]
+
+    segment_token_counts = [math.ceil((end - start) / 4) for start, end in ranges]
+    merged_token_count = sum(segment_token_counts) - 100  # One 4-second overlap at 25 Hz.
+    assert merged_token_count == math.ceil(total_frames / 4)
+
+    # The old loop added (5200, 5201). Half-overlap trimming discarded that
+    # tiny terminal segment and another 50 tokens (exactly two seconds).
+    old_segment_token_counts = segment_token_counts + [1]
+    old_merged_token_count = sum(
+        max(
+            0,
+            count
+            - (50 if index else 0)
+            - (50 if index != len(old_segment_token_counts) - 1 else 0),
+        )
+        for index, count in enumerate(old_segment_token_counts)
+    )
+    assert merged_token_count - old_merged_token_count == 50
+
+
+@pytest.mark.parametrize(
+    "total", (3001, 5000, 5199, 5200, 5201, 5210, 7799, 7800, 7801)
+)
+def test_boundary_lengths_end_exactly_once(total):
+    ranges = long_audio_frame_ranges(
+        total, window_frames=3000, stride_frames=2600
+    )
+    assert ranges[-1][1] == total
+    assert sum(end == total for _, end in ranges) == 1
+    assert all(end > start for start, end in ranges)
+
+
+def test_validates_geometry():
+    with pytest.raises(ValueError):
+        long_audio_frame_ranges(10, window_frames=5, stride_frames=6)


### PR DESCRIPTION
## What changed

- stop long-audio window creation as soon as a window reaches the end of the mel sequence
- isolate the frame-range calculation in a pure helper
- add regression coverage around the 52-second stride boundary

## Root cause

The 30-second window uses a 26-second stride. The old `while start < audio_mel_len` loop advanced once more even when the preceding window had already reached the end. Near stride boundaries this emitted a redundant terminal segment shorter than half of the four-second overlap. `merge_tokenized_segments` then removed half the overlap from both sides, discarded that tiny segment, and shortened the merged 25 Hz clock by 50 tokens (two seconds).

## Impact

Long utterances near those boundaries now produce exactly one terminal window. This prevents the systematic two-second token-clock loss without changing short-audio processing or overlap geometry.

## Validation

- `python3 -m pytest -q test/test_long_audio_clock.py` (11 passed)
- `python3 -m py_compile s3tokenizer/chunking.py s3tokenizer/model_v2.py test/test_long_audio_clock.py`

The regression test checks the exact 5,201-frame failure case and neighboring 30/52/78-second boundaries.
